### PR TITLE
Add API routes and integration tests

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -3,8 +3,18 @@ class CommentsController < ApplicationController
   before_action :set_post
   before_action :set_comment, only: [:show, :update]
 
+  def index
+    query = params[:query].to_s
+    comments = if query.empty?
+                 @post.comments
+               else
+                 Comment.search(query, where: { post_id: @post.id })
+               end
+    render json: comments.map { |c| CommentSerializer.new(c).serializable_hash }
+  end
+
   def create
-    result = CommentContract.new.call(comment_params.to_h)
+    result = CommentContract.new.call(params.to_unsafe_h.merge(post_id: @post.id))
     if result.success?
       comment = @post.comments.create(result.to_h.except(:post_id))
       if comment.persisted?
@@ -24,7 +34,7 @@ class CommentsController < ApplicationController
   end
 
   def update
-    result = CommentContract.new.call(comment_params.to_h)
+    result = CommentContract.new.call(params.to_unsafe_h.merge(post_id: @post.id))
     if result.success?
       if @comment.update(result.to_h.except(:post_id))
         Rails.cache.write("comment:#{@comment.id}", @comment)
@@ -51,7 +61,4 @@ class CommentsController < ApplicationController
     @comment = @post.comments.find(params[:id])
   end
 
-  def comment_params
-    params.permit(:body, :post_id)
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
-  resources :users do
-    resources :posts do
-      resources :comments
+  namespace :api do
+    resources :users, only: [:index, :show, :create, :update] do
+      resources :posts, only: [:index, :show, :create, :update] do
+        resources :comments, only: [:index, :show, :create, :update]
+      end
     end
   end
 end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -1,33 +1,47 @@
 require 'rails_helper'
 
 RSpec.describe 'Comments API', type: :request do
-  let(:user) { create(:user) }
-  let(:post_record) { create(:post, user: user) }
+  100.times do |i|
+    context "run #{i}" do
+      let(:user) { create(:user) }
+      let(:post_record) { create(:post, user: user) }
 
-  describe 'POST /users/:user_id/posts/:post_id/comments' do
-    it 'creates comment and caches it' do
-      post "/users/#{user.id}/posts/#{post_record.id}/comments", params: {body: 'Hi', post_id: post_record.id}
-      expect(response).to have_http_status(:created)
-      data = JSON.parse(response.body)
-      id = data['id']
-      expect(Rails.cache.read("comment:#{id}").body).to eq('Hi')
-      allow(Comment).to receive(:search).with('Hi').and_return([Comment.find(id)])
-      results = Comment.search('Hi')
-      expect(results.first.id).to eq(id)
-    end
+      it 'creates comment and caches it' do
+        post "/api/users/#{user.id}/posts/#{post_record.id}/comments", params: { body: "Hi#{i}", post_id: post_record.id }
+        expect(response).to have_http_status(:created)
+        data = JSON.parse(response.body)
+        id = data['id']
+        expect(Rails.cache.read("comment:#{id}").body).to eq("Hi#{i}")
+        allow(Comment).to receive(:search).with("Hi#{i}", where: { post_id: post_record.id }).and_return([Comment.find(id)])
+        results = Comment.search("Hi#{i}", where: { post_id: post_record.id })
+        expect(results.first.id).to eq(id)
+      end
 
-    it 'returns 422 for invalid params' do
-      post "/users/#{user.id}/posts/#{post_record.id}/comments", params: {foo: 'bar'}
-      expect(response).to have_http_status(:unprocessable_entity)
-    end
-  end
+      it 'returns 422 for invalid params' do
+        post "/api/users/#{user.id}/posts/#{post_record.id}/comments", params: { foo: 'bar' }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
 
-  describe 'PUT /users/:user_id/posts/:post_id/comments/:id' do
-    it 'updates comment and caches result' do
-      comment = create(:comment, post: post_record)
-      put "/users/#{user.id}/posts/#{post_record.id}/comments/#{comment.id}", params: {body: 'Update'}
-      expect(response).to have_http_status(:ok)
-      expect(Rails.cache.read("comment:#{comment.id}").body).to eq('Update')
+      it 'updates comment and caches result' do
+        comment = create(:comment, post: post_record)
+        put "/api/users/#{user.id}/posts/#{post_record.id}/comments/#{comment.id}", params: { body: "Update#{i}" }
+        expect(response).to have_http_status(:ok)
+        expect(Rails.cache.read("comment:#{comment.id}").body).to eq("Update#{i}")
+      end
+
+      it 'searches comments' do
+        comment = create(:comment, post: post_record, body: "Search#{i}")
+        allow(Comment).to receive(:search).with("Search#{i}", where: { post_id: post_record.id }).and_return([comment])
+        get "/api/users/#{user.id}/posts/#{post_record.id}/comments", params: { query: "Search#{i}" }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'shows comment' do
+        comment = create(:comment, post: post_record)
+        Rails.cache.write("comment:#{comment.id}", comment)
+        get "/api/users/#{user.id}/posts/#{post_record.id}/comments/#{comment.id}"
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,32 +1,46 @@
 require 'rails_helper'
 
 RSpec.describe 'Posts API', type: :request do
-  let(:user) { create(:user) }
+  100.times do |i|
+    context "run #{i}" do
+      let(:user) { create(:user) }
 
-  describe 'POST /users/:user_id/posts' do
-    it 'creates post and caches it' do
-      post "/users/#{user.id}/posts", params: {title: 'Title', body: 'Body', user_id: user.id}
-      expect(response).to have_http_status(:created)
-      data = JSON.parse(response.body)
-      id = data['id']
-      expect(Rails.cache.read("post:#{id}").title).to eq('Title')
-      allow(Post).to receive(:search).with('Title').and_return([Post.find(id)])
-      results = Post.search('Title')
-      expect(results.first.id).to eq(id)
-    end
+      it 'creates post and caches it' do
+        post "/api/users/#{user.id}/posts", params: { title: "Title#{i}", body: 'Body', user_id: user.id }
+        expect(response).to have_http_status(:created)
+        data = JSON.parse(response.body)
+        id = data['id']
+        expect(Rails.cache.read("post:#{id}").title).to eq("Title#{i}")
+        allow(Post).to receive(:search).with("Title#{i}", where: { user_id: user.id }).and_return([Post.find(id)])
+        results = Post.search("Title#{i}", where: { user_id: user.id })
+        expect(results.first.id).to eq(id)
+      end
 
-    it 'returns 422 for invalid params' do
-      post "/users/#{user.id}/posts", params: {body: 'Missing title', user_id: user.id}
-      expect(response).to have_http_status(:unprocessable_entity)
-    end
-  end
+      it 'returns 422 for invalid params' do
+        post "/api/users/#{user.id}/posts", params: { body: 'Missing title', user_id: user.id }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
 
-  describe 'PUT /users/:user_id/posts/:id' do
-    it 'updates post and caches result' do
-      post_record = create(:post, user: user)
-      put "/users/#{user.id}/posts/#{post_record.id}", params: {title: 'New'}
-      expect(response).to have_http_status(:ok)
-      expect(Rails.cache.read("post:#{post_record.id}").title).to eq('New')
+      it 'updates post and caches result' do
+        post_record = create(:post, user: user)
+        put "/api/users/#{user.id}/posts/#{post_record.id}", params: { title: "New#{i}" }
+        expect(response).to have_http_status(:ok)
+        expect(Rails.cache.read("post:#{post_record.id}").title).to eq("New#{i}")
+      end
+
+      it 'searches posts' do
+        post_record = create(:post, user: user, title: "Find#{i}")
+        allow(Post).to receive(:search).with("Find#{i}", where: { user_id: user.id }).and_return([post_record])
+        get "/api/users/#{user.id}/posts", params: { query: "Find#{i}" }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'shows post' do
+        post_record = create(:post, user: user)
+        Rails.cache.write("post:#{post_record.id}", post_record)
+        get "/api/users/#{user.id}/posts/#{post_record.id}"
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,41 +1,46 @@
 require 'rails_helper'
 
 RSpec.describe 'Users API', type: :request do
-  describe 'POST /users' do
-    it 'creates user and caches and indexes record' do
-      post '/users', params: {name: 'John'}
-      expect(response).to have_http_status(:created)
-      data = JSON.parse(response.body)
-      id = data['id']
-      expect(Rails.cache.read("user:#{id}").name).to eq('John')
-      allow(User).to receive(:search).with('John').and_return([User.find(id)])
-      results = User.search('John')
-      expect(results.first.id).to eq(id)
-    end
+  100.times do |i|
+    context "run #{i}" do
+      it 'creates user and caches and indexes record' do
+        post '/api/users', params: { name: "John#{i}" }
+        expect(response).to have_http_status(:created)
+        data = JSON.parse(response.body)
+        id = data['id']
+        expect(Rails.cache.read("user:#{id}").name).to eq("John#{i}")
+        allow(User).to receive(:search).with("John#{i}").and_return([User.find(id)])
+        results = User.search("John#{i}")
+        expect(results.first.id).to eq(id)
+      end
 
-    it 'returns 422 for invalid params' do
-      post '/users', params: {foo: 'bar'}
-      expect(response).to have_http_status(:unprocessable_entity)
-    end
-  end
+      it 'returns 422 for invalid params' do
+        post '/api/users', params: { foo: 'bar' }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
 
-  describe 'GET /users/:id' do
-    it 'returns user and hits cache' do
-      user = create(:user, name: 'Cached')
-      Rails.cache.write("user:#{user.id}", user)
-      get "/users/#{user.id}"
-      expect(response).to have_http_status(:ok)
-      data = JSON.parse(response.body)
-      expect(data['name']).to eq('Cached')
-    end
-  end
+      it 'returns user and hits cache' do
+        user = create(:user, name: "Cached#{i}")
+        Rails.cache.write("user:#{user.id}", user)
+        get "/api/users/#{user.id}"
+        expect(response).to have_http_status(:ok)
+        data = JSON.parse(response.body)
+        expect(data['name']).to eq("Cached#{i}")
+      end
 
-  describe 'PUT /users/:id' do
-    it 'updates user and caches result' do
-      user = create(:user)
-      put "/users/#{user.id}", params: {name: 'Updated'}
-      expect(response).to have_http_status(:ok)
-      expect(Rails.cache.read("user:#{user.id}").name).to eq('Updated')
+      it 'updates user and caches result' do
+        user = create(:user)
+        put "/api/users/#{user.id}", params: { name: "Updated#{i}" }
+        expect(response).to have_http_status(:ok)
+        expect(Rails.cache.read("user:#{user.id}").name).to eq("Updated#{i}")
+      end
+
+      it 'searches users' do
+        user = create(:user, name: "Search#{i}")
+        allow(User).to receive(:search).with("Search#{i}").and_return([user])
+        get '/api/users', params: { query: "Search#{i}" }
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- switch to API namespace and restrict routes to index/show/create/update
- remove strong params from controllers and rely on Dry contracts
- add index actions with Searchkick
- remove previous heavy performance specs
- generate 100 repeated request examples for users, posts and comments

## Testing
- `bundle install --local` *(fails: Could not find gems locally)*
- `bundle exec rake db:create` *(fails to load rake)*
- `bundle exec parallel_rspec -n 2 spec` *(fails: command not found: parallel_rspec)*

------
https://chatgpt.com/codex/tasks/task_e_684daa538b348326b6ac6a6913fc3b3a