### PR TITLE
Configure test index suffix for Searchkick

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,16 +2,12 @@
 
 class Comment < ActiveRecord::Base
   belongs_to :post
-  searchkick index_name: -> { "comments_#{ENV['TEST_ENV_NUMBER'] || '0'}" }
+  searchkick
 
   after_commit :index_document
 
-  def index_name
-    "comments_#{ENV['TEST_ENV_NUMBER'] || '0'}"
-  end
-
   def index_document
-    Searchkick.client.index(index: index_name, id: id, body: attributes)
+    Searchkick.client.index(index: searchkick_index.name, id: id, body: attributes)
     Rails.cache.write("comment:#{id}", self)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,16 +3,12 @@
 class Post < ActiveRecord::Base
   belongs_to :user
   has_many :comments
-  searchkick index_name: -> { "posts_#{ENV['TEST_ENV_NUMBER'] || '0'}" }
+  searchkick
 
   after_commit :index_document
 
-  def index_name
-    "posts_#{ENV['TEST_ENV_NUMBER'] || '0'}"
-  end
-
   def index_document
-    Searchkick.client.index(index: index_name, id: id, body: attributes)
+    Searchkick.client.index(index: searchkick_index.name, id: id, body: attributes)
     Rails.cache.write("post:#{id}", self)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,16 +2,12 @@
 
 class User < ActiveRecord::Base
   has_many :posts
-  searchkick index_name: -> { "users_#{ENV['TEST_ENV_NUMBER'] || '0'}" }
+  searchkick
 
   after_commit :index_document
 
-  def index_name
-    "users_#{ENV['TEST_ENV_NUMBER'] || '0'}"
-  end
-
   def index_document
-    Searchkick.client.index(index: index_name, id: id, body: attributes)
+    Searchkick.client.index(index: searchkick_index.name, id: id, body: attributes)
     Rails.cache.write("user:#{id}", self)
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,14 +13,9 @@ require 'rspec/rails'
 require 'factory_bot'
 FactoryBot.definition_file_paths = [File.expand_path('factories', __dir__)]
 FactoryBot.find_definitions
-class FakeSearchClient
-  def index(**kwargs); end
-
-  def bulk(*_args)
-    { 'errors' => false, 'items' => [] }
-  end
-end
-Searchkick.client = FakeSearchClient.new
+require 'opensearch'
+Searchkick.client = OpenSearch::Client.new(url: ENV.fetch('OPENSEARCH_URL', 'http://localhost:9200'))
+Searchkick.index_suffix = ENV.fetch('TEST_ENV_NUMBER', '0')
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
## Summary
- configure a global Searchkick index suffix in `rails_helper`
- simplify models to rely on Searchkick's suffix logic
- use real OpenSearch client in test setup

## Testing
- `bundle exec rubocop`
- `bundle exec rspec` *(fails: could not connect to DB)*

------
https://chatgpt.com/codex/tasks/task_e_684dcc4c54a48326a561b40467090cf5