### PR TITLE
Add Sidekiq worker for post updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'alba'
 gem 'dry-validation'
 gem 'rails', '~> 8.0.0'
 gem 'rswag'
+gem 'sidekiq'
 
 # Linting and style checking
 gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,8 @@ GEM
     rdoc (6.14.0)
       erb
       psych (>= 4.0.0)
+    redis-client (0.24.0)
+      connection_pool
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
@@ -314,6 +316,12 @@ GEM
       activemodel (>= 7.1)
       hashie
     securerandom (0.4.1)
+    sidekiq (8.0.4)
+      connection_pool (>= 2.5.0)
+      json (>= 2.9.0)
+      logger (>= 1.6.2)
+      rack (>= 3.1.0)
+      redis-client (>= 0.23.2)
     stringio (3.1.7)
     thor (1.3.2)
     timeout (0.4.3)
@@ -357,6 +365,7 @@ DEPENDENCIES
   rubocop
   rubocop-rspec
   searchkick
+  sidekiq
 
 BUNDLED WITH
    2.6.9

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,10 +5,9 @@ class Post < ActiveRecord::Base
   has_many :comments
   searchkick
 
-  after_commit :index_document
+  after_commit :enqueue_update_job
 
-  def index_document
-    Searchkick.client.index(index: searchkick_index.name, id: id, body: attributes)
-    Rails.cache.write("post:#{id}", self)
+  def enqueue_update_job
+    UpdatePostBodyWorker.perform_async(id)
   end
 end

--- a/app/workers/update_post_body_worker.rb
+++ b/app/workers/update_post_body_worker.rb
@@ -1,0 +1,12 @@
+class UpdatePostBodyWorker
+  include Sidekiq::Worker
+
+  def perform(post_id)
+    post = Post.find_by(id: post_id)
+    return unless post
+
+    Searchkick.client.index(index: post.searchkick_index.name, id: post.id, body: post.attributes)
+    post.update_column(:body, "#{post.body} processed")
+    Rails.cache.write("post:#{post.id}", post)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,7 +12,9 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'rspec/rails'
 require 'factory_bot'
 FactoryBot.definition_file_paths = [File.expand_path('factories', __dir__)]
-FactoryBot.find_definitions
+# Avoid duplicate factory registrations when `rails_helper` is loaded multiple
+# times in parallel specs.
+FactoryBot.find_definitions unless FactoryBot.factories.registered?(:user)
 require 'opensearch'
 Searchkick.client = OpenSearch::Client.new(url: ENV.fetch('OPENSEARCH_URL', 'http://localhost:9200'))
 Searchkick.index_suffix = ENV.fetch('TEST_ENV_NUMBER', '0')

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'sidekiq/testing'
 
 RSpec.describe 'Posts API', type: :request do
   100.times do |i|
@@ -18,6 +19,18 @@ RSpec.describe 'Posts API', type: :request do
         expect(results.first.id).to eq(id)
       end
 
+      it 'updates body asynchronously after create' do
+        created_id = nil
+        Sidekiq::Testing.inline! do
+          allow(Searchkick.client).to receive(:index)
+          post "/api/users/#{user.id}/posts", params: { title: "AsyncCreate#{i}", body: 'B' }
+          expect(response).to have_http_status(:created)
+          created_id = JSON.parse(response.body)['id']
+        end
+        expect(Searchkick.client).to have_received(:index).at_least(:once)
+        expect(Post.find(created_id).body).to include('processed')
+      end
+
       it 'returns 422 for invalid params' do
         post "/api/users/#{user.id}/posts", params: { body: 'Missing title', user_id: user.id }
         expect(response).to have_http_status(:unprocessable_entity)
@@ -28,6 +41,19 @@ RSpec.describe 'Posts API', type: :request do
         put "/api/users/#{user.id}/posts/#{post_record.id}", params: { title: "New#{i}" }
         expect(response).to have_http_status(:ok)
         expect(Rails.cache.read("post:#{post_record.id}").title).to eq("New#{i}")
+      end
+
+      it 'updates body asynchronously after update' do
+        post_record = nil
+        Sidekiq::Testing.inline! do
+          post_record = create(:post, user: user)
+          allow(Searchkick.client).to receive(:index)
+          put "/api/users/#{user.id}/posts/#{post_record.id}", params: { title: "Async#{i}" }
+          expect(response).to have_http_status(:ok)
+        end
+        expect(Searchkick.client).to have_received(:index).at_least(:once)
+        expect(Rails.cache.read("post:#{post_record.id}").title).to eq("Async#{i}")
+        expect(post_record.reload.body).to include('processed')
       end
 
       it 'searches posts' do


### PR DESCRIPTION
## Summary
- queue `UpdatePostBodyWorker` after commits
- worker appends to the post body and updates cache
- include Sidekiq in dependencies
- integration specs cover create and update scenarios
- drop unused migration

## Testing
- `bundle install`
- `bundle exec rspec` *(fails: could not connect to DB)*

------
https://chatgpt.com/codex/tasks/task_e_684dd5bcab2c83268080fb8e61d7a043